### PR TITLE
Cipher refactor

### DIFF
--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -4,7 +4,7 @@ class Cipher
     @character_set = ("a".."z").to_a << " "
   end
 
-  def encode(word, offset)
+  def shift(word, offset)
     shifted_set = @character_set.rotate(offset)
     word.downcase.split("").map do |character|
       determine_character(character, shifted_set)
@@ -17,11 +17,6 @@ class Cipher
     else
       character
     end
-  end
-
-  def decode(word, offset)
-    Cipher.instance_method(:encode).bind(self).call(word, offset * -1)
-    # encode(word, offset * -1)
   end
 
 end

--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -6,7 +6,7 @@ class Cipher
 
   def shift(word, offset)
     shifted_set = @character_set.rotate(offset)
-    word.downcase.split.map do |character|
+    word.downcase.split("").map do |character|
       determine_character(character, shifted_set)
     end.join
   end

--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -6,9 +6,9 @@ class Cipher
 
   def shift(word, offset)
     shifted_set = @character_set.rotate(offset)
-    word.downcase.split("").map do |character|
+    word.downcase.split.map do |character|
       determine_character(character, shifted_set)
-    end.join("")
+    end.join
   end
 
   def determine_character(character, shifted_set)

--- a/lib/enigma_cipher.rb
+++ b/lib/enigma_cipher.rb
@@ -28,11 +28,13 @@ class EnigmaCipher < Cipher
 
   def encode(word, key, date)
     shifts = generate_shifts(key, date)
-    grouped_letters = group_letters_by_shift(word)
-    grouped_letters.each do |shift, letters|
-      grouped_letters[shift] = super(letters.join(""), shifts[shift])
-    end
-    reassemble_message(grouped_letters, word.length)
+    shift(word, shifts)
+  end
+
+  def shift(word, shifts)
+    word.split("").map.with_index do |letter, index|
+      super(letter, shifts[index % 4])
+    end.join
   end
 
   def decode(word, key, date)

--- a/lib/enigma_cipher.rb
+++ b/lib/enigma_cipher.rb
@@ -42,19 +42,4 @@ class EnigmaCipher < Cipher
     shifts = shifts.map {|amount| -amount}
     shift(word, shifts)
   end
-
-  def group_letters_by_shift(word)
-    split_word = word.downcase.split("")
-    split_word.group_by.with_index do |letter, index|
-      index % 4
-    end
-  end
-
-  def reassemble_message(grouped_letters, message_size)
-    result = ""
-    message_size.times.with_index do |index|
-      result += grouped_letters[index % 4][index / 4]
-    end
-    result
-  end
 end

--- a/lib/enigma_cipher.rb
+++ b/lib/enigma_cipher.rb
@@ -39,11 +39,8 @@ class EnigmaCipher < Cipher
 
   def decode(word, key, date)
     shifts = generate_shifts(key, date)
-    grouped_letters = group_letters_by_shift(word)
-    grouped_letters.each do |shift, letters|
-      grouped_letters[shift] = super(letters.join(""), shifts[shift])
-    end
-    reassemble_message(grouped_letters, word.length)
+    shifts = shifts.map {|amount| -amount}
+    shift(word, shifts)
   end
 
   def group_letters_by_shift(word)

--- a/test/cipher_test.rb
+++ b/test/cipher_test.rb
@@ -13,26 +13,21 @@ class CipherTest < Minitest::Test
 
   def test_it_can_translate_words_given_an_offset
     # skip
-    assert_equal "bcdef", @cipher.encode("abcde", 1)
+    assert_equal "bcdef", @cipher.shift("abcde", 1)
   end
 
   def test_translated_words_can_contain_spaces
     # skip
-    assert_equal "ifmmpaxpsme", @cipher.encode("hello world", 1)
+    assert_equal "ifmmpaxpsme", @cipher.shift("hello world", 1)
   end
 
   def test_encoded_words_are_translated_to_lower_case
     # skip
-    assert_equal "ifmmpaxpsme", @cipher.encode("HELLO WORLD", 1)
+    assert_equal "ifmmpaxpsme", @cipher.shift("HELLO WORLD", 1)
   end
 
   def test_only_alphabetical_and_whitespace_is_encoded
     # skip
-    assert_equal "ifmmpaxpsme?!", @cipher.encode("hello world?!", 1)
-  end
-
-  def test_it_can_decode_words_using_an_offset
-    # skip
-    assert_equal "hello world?!", @cipher.decode("ifmmpaxpsme?!", 1)
+    assert_equal "ifmmpaxpsme?!", @cipher.shift("hello world?!", 1)
   end
 end

--- a/test/enigma_cipher_test.rb
+++ b/test/enigma_cipher_test.rb
@@ -46,24 +46,4 @@ class EnigmaCipherTest < Minitest::Test
     assert_equal "test", @cipher.decode("test", "00000", "000000")
   end
 
-  def test_it_can_group_letters_by_cipher_shift
-    # skip
-    expected = {0 => ["h","o","r"],
-                1 => ["e"," ","l"],
-                2 => ["l", "w", "d"],
-                3 => ["l", "o"]}
-
-    assert_equal expected, @cipher.group_letters_by_shift("hello world")
-  end
-
-  def test_it_can_reassemble_a_grouping_of_letters
-    # skip
-    grouping = {0 => ["h","o","r"],
-                1 => ["e"," ","l"],
-                2 => ["l", "w", "d"],
-                3 => ["l", "o"]}
-
-    assert_equal "hello world", @cipher.reassemble_message(grouping, 11)
-  end
-
 end


### PR DESCRIPTION
Refactors cipher class to use shift over separate encode and decode methods. Adjusts tests and dependencies on encode and decode to reflect new usage.